### PR TITLE
Update to Spring Boot 3.3.0-M1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-    springBootVersion = '3.2.2'
+    springBootVersion = '3.3.0-M1'
     springCloudVersion = '2023.0.0'
     springCloudAwsVersion = '3.0.4'
 

--- a/function/spring-aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/CustomPropsAndMongoMessageStoreAggregatorTests.java
+++ b/function/spring-aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/CustomPropsAndMongoMessageStoreAggregatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 the original author or authors.
+ * Copyright 2020-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
 package org.springframework.cloud.fn.aggregator;
 
 import java.time.Duration;
-import java.util.List;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
@@ -60,11 +60,8 @@ public class CustomPropsAndMongoMessageStoreAggregatorTests extends AbstractAggr
 
 		output.as(StepVerifier::create)
 			.assertNext((message) -> assertThat(message).extracting(Message::getPayload)
-				.isInstanceOf(List.class)
-				.asList()
-				.hasSize(1)
-				.element(0)
-				.isEqualTo("foo"))
+				.asInstanceOf(InstanceOfAssertFactories.LIST)
+				.containsExactly("foo"))
 			.thenCancel()
 			.verify(Duration.ofSeconds(10));
 

--- a/function/spring-aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/DefaultAggregatorTests.java
+++ b/function/spring-aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/DefaultAggregatorTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.fn.aggregator;
 
 import java.time.Duration;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
@@ -57,9 +58,8 @@ public class DefaultAggregatorTests extends AbstractAggregatorFunctionTests {
 		output.log("DefaultAggregatorTests:output")
 			.as(StepVerifier::create)
 			.assertNext((message) -> assertThat(message).extracting(Message::getPayload)
-				.asList()
-				.hasSize(2)
-				.contains("1", "2"))
+				.asInstanceOf(InstanceOfAssertFactories.LIST)
+				.containsExactlyInAnyOrder("1", "2"))
 			.thenCancel()
 			.verify(Duration.ofSeconds(30));
 

--- a/function/spring-aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/JdbcMessageStoreAggregatorTests.java
+++ b/function/spring-aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/JdbcMessageStoreAggregatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 the original author or authors.
+ * Copyright 2020-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.cloud.fn.aggregator;
 import java.time.Duration;
 import java.util.List;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
@@ -57,9 +58,8 @@ public class JdbcMessageStoreAggregatorTests extends AbstractAggregatorFunctionT
 		output.as(StepVerifier::create)
 			.assertNext((message) -> assertThat(message).extracting(Message::getPayload)
 				.isInstanceOf(List.class)
-				.asList()
-				.hasSize(2)
-				.contains("1", "2"))
+				.asInstanceOf(InstanceOfAssertFactories.LIST)
+				.containsExactlyInAnyOrder("1", "2"))
 			.thenCancel()
 			.verify(Duration.ofSeconds(10));
 

--- a/function/spring-aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/RedisMessageStoreAggregatorTests.java
+++ b/function/spring-aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/RedisMessageStoreAggregatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 the original author or authors.
+ * Copyright 2020-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ package org.springframework.cloud.fn.aggregator;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.time.Duration;
-import java.util.List;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
@@ -70,10 +70,8 @@ public class RedisMessageStoreAggregatorTests extends AbstractAggregatorFunction
 
 		output.as(StepVerifier::create)
 			.assertNext((message) -> assertThat(message).extracting(Message::getPayload)
-				.isInstanceOf(List.class)
-				.asList()
-				.hasSize(2)
-				.contains("1", "2"))
+				.asInstanceOf(InstanceOfAssertFactories.LIST)
+				.containsExactlyInAnyOrder("1", "2"))
 			.thenCancel()
 			.verify(Duration.ofSeconds(10));
 


### PR DESCRIPTION
This commit updates the spring-boot-dependencies version to `3.3.0-M1`.

This update also transitively updates the AssertJ core library to version `3.25.1` which introduces a deprecation for `AbstractAssert#toList`. As such, these deprecated usages are replaced in several tests with `AbstractAssert#asInstanceOf`.

Resolves #10

<!--
Thanks for contributing to Spring Functions Catalog. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
