### PR TITLE
Replace synchronized blocks with ReentrantLocks for virtual thread support

### DIFF
--- a/consumer/spring-cassandra-consumer/src/main/java/org/springframework/cloud/fn/consumer/cassandra/CassandraConsumerConfiguration.java
+++ b/consumer/spring-cassandra-consumer/src/main/java/org/springframework/cloud/fn/consumer/cassandra/CassandraConsumerConfiguration.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -147,6 +149,8 @@ public class CassandraConsumerConfiguration {
 
 		private final ISO8601StdDateFormat dateFormat = new ISO8601StdDateFormat();
 
+		private final Lock dateLock = new ReentrantLock();
+
 		PayloadToMatrixTransformer(ObjectMapper objectMapper, String query, ColumnNameExtractor columnNameExtractor) {
 			this.jsonObjectMapper = new Jackson2JsonObjectMapper(objectMapper);
 			this.columns.addAll(columnNameExtractor.extract(query));
@@ -170,8 +174,12 @@ public class CassandraConsumerConfiguration {
 							Object value = entity.get(column);
 							if (value instanceof String string) {
 								if (this.dateFormat.looksLikeISO8601(string)) {
-									synchronized (this.dateFormat) {
+									try {
+										this.dateLock.lock();
 										value = new Date(this.dateFormat.parse(string).getTime()).toLocalDate();
+									}
+									finally {
+										this.dateLock.unlock();
 									}
 								}
 								if (isUuid(string)) {

--- a/consumer/spring-cassandra-consumer/src/main/java/org/springframework/cloud/fn/consumer/cassandra/CassandraConsumerConfiguration.java
+++ b/consumer/spring-cassandra-consumer/src/main/java/org/springframework/cloud/fn/consumer/cassandra/CassandraConsumerConfiguration.java
@@ -64,6 +64,7 @@ import org.springframework.util.StringUtils;
  * @author Thomas Risberg
  * @author Ashu Gairola
  * @author Akos Ratku
+ * @author Omer Celik
  */
 @AutoConfiguration(after = CassandraReactiveDataAutoConfiguration.class)
 @EnableConfigurationProperties(CassandraConsumerProperties.class)
@@ -174,8 +175,8 @@ public class CassandraConsumerConfiguration {
 							Object value = entity.get(column);
 							if (value instanceof String string) {
 								if (this.dateFormat.looksLikeISO8601(string)) {
+									this.dateLock.lock();
 									try {
-										this.dateLock.lock();
 										value = new Date(this.dateFormat.parse(string).getTime()).toLocalDate();
 									}
 									finally {

--- a/consumer/spring-websocket-consumer/src/main/java/org/springframework/cloud/fn/consumer/websocket/trace/InMemoryTraceRepository.java
+++ b/consumer/spring-websocket-consumer/src/main/java/org/springframework/cloud/fn/consumer/websocket/trace/InMemoryTraceRepository.java
@@ -21,6 +21,8 @@ import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * A repository for {@link Trace}s.
@@ -41,13 +43,19 @@ public class InMemoryTraceRepository {
 
 	private final List<Trace> traces = new LinkedList<>();
 
+	private final Lock tracesLock = new ReentrantLock();
+
 	/**
 	 * Flag to say that the repository lists traces in reverse order.
 	 * @param reverse flag value (default true)
 	 */
 	public void setReverse(boolean reverse) {
-		synchronized (this.traces) {
+		try {
+			this.tracesLock.lock();
 			this.reverse = reverse;
+		}
+		finally {
+			this.tracesLock.unlock();
 		}
 	}
 
@@ -56,20 +64,29 @@ public class InMemoryTraceRepository {
 	 * @param capacity the capacity
 	 */
 	public void setCapacity(int capacity) {
-		synchronized (this.traces) {
+		try {
+			this.tracesLock.lock();
 			this.capacity = capacity;
+		}
+		finally {
+			this.tracesLock.unlock();
 		}
 	}
 
 	public List<Trace> findAll() {
-		synchronized (this.traces) {
+		try {
+			this.tracesLock.lock();
 			return Collections.unmodifiableList(this.traces);
+		}
+		finally {
+			this.tracesLock.unlock();
 		}
 	}
 
 	public void add(Map<String, Object> map) {
 		Trace trace = new Trace(new Date(), map);
-		synchronized (this.traces) {
+		try {
+			this.tracesLock.lock();
 			while (this.traces.size() >= this.capacity) {
 				this.traces.remove(this.reverse ? this.capacity - 1 : 0);
 			}
@@ -79,6 +96,9 @@ public class InMemoryTraceRepository {
 			else {
 				this.traces.add(trace);
 			}
+		}
+		finally {
+			this.tracesLock.unlock();
 		}
 	}
 

--- a/consumer/spring-websocket-consumer/src/main/java/org/springframework/cloud/fn/consumer/websocket/trace/InMemoryTraceRepository.java
+++ b/consumer/spring-websocket-consumer/src/main/java/org/springframework/cloud/fn/consumer/websocket/trace/InMemoryTraceRepository.java
@@ -51,13 +51,7 @@ public class InMemoryTraceRepository {
 	 * @param reverse flag value (default true)
 	 */
 	public void setReverse(boolean reverse) {
-		this.tracesLock.lock();
-		try {
-			this.reverse = reverse;
-		}
-		finally {
-			this.tracesLock.unlock();
-		}
+		this.reverse = reverse;
 	}
 
 	/**
@@ -65,23 +59,11 @@ public class InMemoryTraceRepository {
 	 * @param capacity the capacity
 	 */
 	public void setCapacity(int capacity) {
-		this.tracesLock.lock();
-		try {
-			this.capacity = capacity;
-		}
-		finally {
-			this.tracesLock.unlock();
-		}
+		this.capacity = capacity;
 	}
 
 	public List<Trace> findAll() {
-		this.tracesLock.lock();
-		try {
-			return Collections.unmodifiableList(this.traces);
-		}
-		finally {
-			this.tracesLock.unlock();
-		}
+		return Collections.unmodifiableList(this.traces);
 	}
 
 	public void add(Map<String, Object> map) {

--- a/consumer/spring-websocket-consumer/src/main/java/org/springframework/cloud/fn/consumer/websocket/trace/InMemoryTraceRepository.java
+++ b/consumer/spring-websocket-consumer/src/main/java/org/springframework/cloud/fn/consumer/websocket/trace/InMemoryTraceRepository.java
@@ -33,6 +33,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @author Dave Syer
  * @author Olivier Bourgain
  * @author Artem Bilan
+ * @author Omer Celik
  * @since 2.0
  */
 public class InMemoryTraceRepository {
@@ -50,8 +51,8 @@ public class InMemoryTraceRepository {
 	 * @param reverse flag value (default true)
 	 */
 	public void setReverse(boolean reverse) {
+		this.tracesLock.lock();
 		try {
-			this.tracesLock.lock();
 			this.reverse = reverse;
 		}
 		finally {
@@ -64,8 +65,8 @@ public class InMemoryTraceRepository {
 	 * @param capacity the capacity
 	 */
 	public void setCapacity(int capacity) {
+		this.tracesLock.lock();
 		try {
-			this.tracesLock.lock();
 			this.capacity = capacity;
 		}
 		finally {
@@ -74,8 +75,8 @@ public class InMemoryTraceRepository {
 	}
 
 	public List<Trace> findAll() {
+		this.tracesLock.lock();
 		try {
-			this.tracesLock.lock();
 			return Collections.unmodifiableList(this.traces);
 		}
 		finally {
@@ -85,8 +86,8 @@ public class InMemoryTraceRepository {
 
 	public void add(Map<String, Object> map) {
 		Trace trace = new Trace(new Date(), map);
+		this.tracesLock.lock();
 		try {
-			this.tracesLock.lock();
 			while (this.traces.size() >= this.capacity) {
 				this.traces.remove(this.reverse ? this.capacity - 1 : 0);
 			}


### PR DESCRIPTION
Replace **synchronized** methods and blocks with **ReentrantLocks** in a few classes in Spring Functions Catalog to improve compatibility with virtual threads. This changes the synchronization mechanism in:

**CassandraConsumerConfiguration.PayloadToMatrixTransformer**
**InMemoryTraceRepository**

The change helps avoid blocking virtual threads when using Spring Functions Catalog in Project Loom environments while maintaining thread safety.