### PR TITLE
Use spring-cloud-function-dependencies in time-spel-log

### DIFF
--- a/samples/time-spel-log/build.gradle
+++ b/samples/time-spel-log/build.gradle
@@ -17,13 +17,13 @@ repositories {
 }
 
 ext {
-    springCloudVersion = '2024.0.1-SNAPSHOT'
+    springCloudFunctionVersion = '4.2.1-SNAPSHOT'
     springFunctionsCatalogVersion = '5.1.0-SNAPSHOT'
 }
 
 dependencyManagement {
     imports {
-        mavenBom "org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion"
+        mavenBom "org.springframework.cloud:spring-cloud-function-dependencies:$springCloudFunctionVersion"
         mavenBom "org.springframework.cloud.fn:spring-functions-catalog-bom:$springFunctionsCatalogVersion"
     }
 }


### PR DESCRIPTION
This replaces the use of `spring-cloud-dependencies` in time-spel-log with `spring-cloud-function-dependencies` in order to:

- narrow dependencies to only what the sample needs

- pick up spring-cloud/spring-cloud-function#1224 which will be released earlier than Spring Cloud `2024.0.1` in Spring Cloud Function `4.2.1`

<!--
Thanks for contributing to Spring Functions Catalog. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
